### PR TITLE
Add comprehensive examples section to documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,12 @@ makedocs(;
             "getting-started/installation.md",
             "getting-started/quickstart.md",
         ],
+        "Examples" => [
+            "examples/option-pricing.md",
+            "examples/portfolio-risk.md",
+            "examples/yield-curve.md",
+            "examples/monte-carlo-exotic.md",
+        ],
         "Manual" => [
             "manual/backends.md",
             "manual/montecarlo.md",

--- a/docs/src/examples/monte-carlo-exotic.md
+++ b/docs/src/examples/monte-carlo-exotic.md
@@ -1,0 +1,406 @@
+# Monte Carlo Exotic Options
+
+This example demonstrates pricing exotic options using Monte Carlo simulation with various variance reduction techniques.
+
+## Setup
+
+```julia
+using Quasar
+```
+
+## Basic Monte Carlo Pricing
+
+### European Options (Benchmark)
+
+Start with European options to verify against Black-Scholes:
+
+```julia
+S0 = 100.0   # Initial spot
+K = 100.0    # Strike
+T = 1.0      # Time to maturity
+r = 0.05     # Risk-free rate
+σ = 0.20     # Volatility
+
+dynamics = GBMDynamics(r, σ)
+
+# Monte Carlo price
+result = mc_price(S0, T, EuropeanCall(K), dynamics;
+    npaths = 100000,
+    nsteps = 252,
+    antithetic = true
+)
+
+# Black-Scholes benchmark
+bs_price = black_scholes(S0, K, T, r, σ, :call)
+
+println("European Call (K=100):")
+println("  Monte Carlo: \$$(round(result.price, digits=4)) ± $(round(result.stderr, digits=4))")
+println("  Black-Scholes: \$$(round(bs_price, digits=4))")
+println("  Error: $(round(abs(result.price - bs_price), digits=4))")
+println("  95% CI: [\$$(round(result.ci_lower, digits=4)), \$$(round(result.ci_upper, digits=4))]")
+```
+
+## Asian Options
+
+Asian options depend on the average price over the life of the option:
+
+```julia
+# Asian call: max(avg(S) - K, 0)
+asian_call = AsianCall(100.0)
+asian_put = AsianPut(100.0)
+
+result_call = mc_price(S0, T, asian_call, dynamics;
+    npaths = 100000,
+    nsteps = 252  # Daily averaging
+)
+
+result_put = mc_price(S0, T, asian_put, dynamics;
+    npaths = 100000,
+    nsteps = 252
+)
+
+println("\nAsian Options (K=100, daily averaging):")
+println("  Call: \$$(round(result_call.price, digits=4)) ± $(round(result_call.stderr, digits=4))")
+println("  Put:  \$$(round(result_put.price, digits=4)) ± $(round(result_put.stderr, digits=4))")
+
+# Compare to European
+eu_call = mc_price(S0, T, EuropeanCall(100.0), dynamics; npaths=100000)
+println("\n  Asian call is $(round((1 - result_call.price/eu_call.price)*100, digits=1))% cheaper than European")
+println("  (Averaging reduces volatility exposure)")
+```
+
+### Averaging Frequency Impact
+
+```julia
+println("\nImpact of Averaging Frequency:")
+for nsteps in [12, 52, 252]
+    freq = nsteps == 12 ? "Monthly" : (nsteps == 52 ? "Weekly" : "Daily")
+    result = mc_price(S0, T, AsianCall(100.0), dynamics;
+        npaths=50000, nsteps=nsteps)
+    println("  $freq: \$$(round(result.price, digits=4))")
+end
+```
+
+## Barrier Options
+
+Barrier options are knocked out (or in) when the price crosses a barrier:
+
+```julia
+# Up-and-out call: knocked out if S ≥ barrier
+K = 100.0
+B = 130.0  # Barrier
+
+up_out_call = UpAndOutCall(K, B)
+
+result = mc_price(S0, T, up_out_call, dynamics;
+    npaths = 100000,
+    nsteps = 252
+)
+
+println("\nUp-and-Out Call (K=100, B=130):")
+println("  Price: \$$(round(result.price, digits=4)) ± $(round(result.stderr, digits=4))")
+
+# Compare to vanilla
+vanilla = mc_price(S0, T, EuropeanCall(K), dynamics; npaths=100000)
+println("  European Call: \$$(round(vanilla.price, digits=4))")
+println("  Knockout discount: $(round((1 - result.price/vanilla.price)*100, digits=1))%")
+```
+
+### Down-and-Out Put
+
+```julia
+# Down-and-out put: knocked out if S ≤ barrier
+K = 100.0
+B = 80.0  # Barrier
+
+down_out_put = DownAndOutPut(K, B)
+
+result = mc_price(S0, T, down_out_put, dynamics;
+    npaths = 100000,
+    nsteps = 252
+)
+
+println("\nDown-and-Out Put (K=100, B=80):")
+println("  Price: \$$(round(result.price, digits=4))")
+```
+
+### Barrier Monitoring Frequency
+
+```julia
+println("\nBarrier Monitoring Frequency Impact:")
+println("(More monitoring = more chances to hit barrier = lower price)")
+for nsteps in [12, 52, 252, 504]
+    result = mc_price(S0, T, UpAndOutCall(100.0, 120.0), dynamics;
+        npaths = 50000,
+        nsteps = nsteps
+    )
+    println("  $nsteps steps/year: \$$(round(result.price, digits=4))")
+end
+```
+
+## American Options (Longstaff-Schwartz)
+
+American options can be exercised early. The Longstaff-Schwartz algorithm uses regression to estimate continuation values:
+
+```julia
+# American put (early exercise is valuable when ITM)
+am_put = AmericanPut(100.0)
+
+result = lsm_price(S0, T, am_put, dynamics;
+    npaths = 50000,
+    nsteps = 50  # Exercise dates
+)
+
+println("\nAmerican Put (K=100):")
+println("  Price: \$$(round(result.price, digits=4))")
+
+# European put for comparison
+eu_put = mc_price(S0, T, EuropeanPut(100.0), dynamics; npaths=50000)
+premium = result.price - eu_put.price
+println("  European Put: \$$(round(eu_put.price, digits=4))")
+println("  Early Exercise Premium: \$$(round(premium, digits=4)) ($(round(premium/eu_put.price*100, digits=1))%)")
+```
+
+### American vs European by Moneyness
+
+```julia
+println("\nEarly Exercise Premium by Moneyness:")
+println("Strike | American | European | Premium")
+println("-"^45)
+for K in [80.0, 90.0, 100.0, 110.0, 120.0]
+    am = lsm_price(S0, T, AmericanPut(K), dynamics; npaths=30000, nsteps=50)
+    eu = mc_price(S0, T, EuropeanPut(K), dynamics; npaths=30000)
+    premium = am.price - eu.price
+    pct = eu.price > 0.01 ? premium / eu.price * 100 : 0.0
+    println("$(Int(K))     | $(round(am.price, digits=2))      | $(round(eu.price, digits=2))      | $(round(premium, digits=2)) ($(round(pct, digits=1))%)")
+end
+```
+
+## Variance Reduction Techniques
+
+### Antithetic Variates
+
+Uses negatively correlated path pairs to reduce variance:
+
+```julia
+# Without antithetic
+result_no_anti = mc_price(S0, T, EuropeanCall(100.0), dynamics;
+    npaths = 50000,
+    antithetic = false
+)
+
+# With antithetic
+result_anti = mc_price(S0, T, EuropeanCall(100.0), dynamics;
+    npaths = 50000,  # Same number of paths
+    antithetic = true
+)
+
+println("\nAntithetic Variates Impact:")
+println("  Without: \$$(round(result_no_anti.price, digits=4)) ± $(round(result_no_anti.stderr, digits=4))")
+println("  With:    \$$(round(result_anti.price, digits=4)) ± $(round(result_anti.stderr, digits=4))")
+println("  Variance reduction: $(round((1 - (result_anti.stderr/result_no_anti.stderr)^2)*100, digits=1))%")
+```
+
+### Quasi-Monte Carlo (Sobol Sequences)
+
+QMC uses low-discrepancy sequences for better convergence:
+
+```julia
+# Standard MC
+result_mc = mc_price(S0, T, EuropeanCall(100.0), dynamics;
+    npaths = 10000,
+    nsteps = 50
+)
+
+# Quasi-Monte Carlo
+result_qmc = mc_price_qmc(S0, T, EuropeanCall(100.0), dynamics;
+    npaths = 10000,
+    nsteps = 50
+)
+
+println("\nQMC vs Standard MC (10,000 paths):")
+println("  Standard MC: \$$(round(result_mc.price, digits=4)) ± $(round(result_mc.stderr, digits=4))")
+println("  QMC:         \$$(round(result_qmc.price, digits=4))")
+```
+
+### Convergence Comparison
+
+```julia
+println("\nConvergence Analysis:")
+println("Paths  | MC Error  | QMC Error | MC Stderr")
+println("-"^50)
+
+bs_price = black_scholes(S0, K, T, r, σ, :call)
+
+for npaths in [1000, 5000, 10000, 50000]
+    mc = mc_price(S0, T, EuropeanCall(K), dynamics; npaths=npaths, nsteps=50)
+    qmc = mc_price_qmc(S0, T, EuropeanCall(K), dynamics; npaths=npaths, nsteps=50)
+
+    mc_err = abs(mc.price - bs_price)
+    qmc_err = abs(qmc.price - bs_price)
+
+    println("$(lpad(npaths, 6)) | $(round(mc_err, digits=4))    | $(round(qmc_err, digits=4))    | $(round(mc.stderr, digits=4))")
+end
+```
+
+## Stochastic Volatility (Heston)
+
+The Heston model has stochastic variance:
+
+```julia
+# Heston parameters
+heston = HestonDynamics(
+    0.05,   # r - risk-free rate
+    0.04,   # v0 - initial variance
+    2.0,    # κ - mean reversion speed
+    0.04,   # θ - long-term variance
+    0.3,    # ξ - vol of vol
+    -0.7    # ρ - correlation (negative = leverage effect)
+)
+
+# MC price under Heston
+result = mc_price(S0, T, EuropeanCall(100.0), heston;
+    npaths = 50000,
+    nsteps = 252
+)
+
+# Compare to semi-analytical Heston
+params = HestonParams(0.04, 0.04, 2.0, 0.3, -0.7)
+analytical = heston_price(S0, 100.0, T, 0.05, params, :call)
+
+println("\nHeston Model European Call:")
+println("  Monte Carlo: \$$(round(result.price, digits=4)) ± $(round(result.stderr, digits=4))")
+println("  Semi-analytical: \$$(round(analytical, digits=4))")
+```
+
+### Heston Smile
+
+```julia
+println("\nHeston Implied Volatility Smile:")
+println("Strike | MC Price | Implied Vol")
+println("-"^40)
+
+for K in [80.0, 90.0, 100.0, 110.0, 120.0]
+    result = mc_price(S0, T, EuropeanCall(K), heston; npaths=30000, nsteps=100)
+
+    # Back out implied vol
+    iv = implied_vol_search(result.price, S0, K, T, r)
+    println("$(Int(K))     | \$$(round(result.price, digits=3))   | $(round(iv*100, digits=2))%")
+end
+
+# Helper function
+function implied_vol_search(price, S, K, T, r; tol=1e-6)
+    σ_low, σ_high = 0.01, 2.0
+    for _ in 1:100
+        σ_mid = (σ_low + σ_high) / 2
+        model_price = black_scholes(S, K, T, r, σ_mid, :call)
+        if abs(model_price - price) < tol
+            return σ_mid
+        elseif model_price > price
+            σ_high = σ_mid
+        else
+            σ_low = σ_mid
+        end
+    end
+    return (σ_low + σ_high) / 2
+end
+```
+
+## Monte Carlo Greeks
+
+Compute sensitivities via pathwise differentiation:
+
+```julia
+using Enzyme  # Or ForwardDiff
+
+dynamics = GBMDynamics(0.05, 0.20)
+payoff = EuropeanCall(100.0)
+
+# Delta only
+delta = mc_delta(S0, T, payoff, dynamics;
+    npaths = 10000,
+    nsteps = 50,
+    backend = EnzymeBackend()
+)
+
+# Delta and Vega together
+greeks = mc_greeks(S0, T, payoff, dynamics;
+    npaths = 10000,
+    nsteps = 50,
+    backend = EnzymeBackend()
+)
+
+println("\nMonte Carlo Greeks:")
+println("  Delta: $(round(delta, digits=4))")
+println("  Vega:  $(round(greeks.vega, digits=4))")
+
+# Compare to analytical
+bs_delta, _, bs_vega, _, _ = black_scholes_greeks(S0, K, T, r, σ, :call)
+println("\nBlack-Scholes Greeks:")
+println("  Delta: $(round(bs_delta, digits=4))")
+println("  Vega:  $(round(bs_vega, digits=4))")
+```
+
+## Path Simulation
+
+For custom payoffs or analysis, simulate paths directly:
+
+```julia
+# Simulate a single GBM path
+dynamics = GBMDynamics(0.05, 0.20)
+path = Quasar.MonteCarlo.simulate_gbm(S0, T, 252, dynamics)
+
+println("\nSimulated GBM Path:")
+println("  Initial: \$$(round(path[1], digits=2))")
+println("  Final:   \$$(round(path[end], digits=2))")
+println("  Min:     \$$(round(minimum(path), digits=2))")
+println("  Max:     \$$(round(maximum(path), digits=2))")
+
+# Antithetic pair
+path1, path2 = Quasar.MonteCarlo.simulate_gbm_antithetic(S0, T, 252, dynamics)
+println("\nAntithetic Pair:")
+println("  Path 1 final: \$$(round(path1[end], digits=2))")
+println("  Path 2 final: \$$(round(path2[end], digits=2))")
+
+# QMC path (deterministic)
+Z = sobol_normals(252, 1)
+path_qmc = Quasar.MonteCarlo.simulate_gbm_qmc(S0, T, 252, dynamics, Z[1, :])
+println("\nQMC Path (deterministic):")
+println("  Final: \$$(round(path_qmc[end], digits=2))")
+```
+
+## Custom Payoffs
+
+Implement custom exotic payoffs:
+
+```julia
+# Example: Lookback call (payoff = S_max - K)
+function price_lookback_call(S0, T, K, dynamics; npaths=50000, nsteps=252)
+    total_payoff = 0.0
+
+    for _ in 1:npaths
+        path = Quasar.MonteCarlo.simulate_gbm(S0, T, nsteps, dynamics)
+        S_max = maximum(path)
+        payoff = max(S_max - K, 0)
+        total_payoff += payoff
+    end
+
+    r = dynamics.r
+    return exp(-r * T) * total_payoff / npaths
+end
+
+lookback_price = price_lookback_call(S0, T, 100.0, dynamics)
+println("\nLookback Call (K=100):")
+println("  Price: \$$(round(lookback_price, digits=4))")
+
+# Compare to vanilla
+vanilla = black_scholes(S0, 100.0, T, 0.05, 0.20, :call)
+println("  European Call: \$$(round(vanilla, digits=4))")
+println("  Lookback premium: $(round((lookback_price/vanilla - 1)*100, digits=1))%")
+```
+
+## Next Steps
+
+- [Option Pricing](option-pricing.md) - Black-Scholes basics
+- [Portfolio Risk](portfolio-risk.md) - Risk management
+- [Monte Carlo Manual](../manual/montecarlo.md) - Full reference

--- a/docs/src/examples/option-pricing.md
+++ b/docs/src/examples/option-pricing.md
@@ -1,0 +1,210 @@
+# Option Pricing Walkthrough
+
+This example demonstrates the complete workflow for pricing European options and computing Greeks.
+
+## Setup
+
+```julia
+using Quasar
+```
+
+## Black-Scholes Pricing
+
+Let's price a European call option on Apple stock.
+
+### Direct Black-Scholes
+
+The simplest approach uses the `black_scholes` function directly:
+
+```julia
+# Parameters
+S = 150.0   # Current stock price
+K = 155.0   # Strike price
+T = 0.5     # Time to expiry (6 months)
+r = 0.05    # Risk-free rate (5%)
+σ = 0.20    # Volatility (20%)
+
+# Price call and put
+call_price = black_scholes(S, K, T, r, σ, :call)
+put_price = black_scholes(S, K, T, r, σ, :put)
+
+println("Call price: \$$(round(call_price, digits=4))")
+println("Put price: \$$(round(put_price, digits=4))")
+
+# Verify put-call parity: C - P = S - K*exp(-rT)
+parity_lhs = call_price - put_price
+parity_rhs = S - K * exp(-r * T)
+println("Put-call parity check: $(round(parity_lhs, digits=6)) ≈ $(round(parity_rhs, digits=6))")
+```
+
+### Using Instruments and Market State
+
+For portfolio management, use the object-oriented approach:
+
+```julia
+# Define market conditions
+state = MarketState(
+    prices = Dict("AAPL" => 150.0),
+    rates = Dict("USD" => 0.05),
+    volatilities = Dict("AAPL" => 0.20)
+)
+
+# Create option instruments
+call = EuropeanOption("AAPL", 155.0, 0.5, :call)
+put = EuropeanOption("AAPL", 155.0, 0.5, :put)
+
+# Price them
+println("Call: \$$(round(price(call, state), digits=4))")
+println("Put: \$$(round(price(put, state), digits=4))")
+```
+
+## Computing Greeks
+
+### First-Order Greeks
+
+Greeks measure option sensitivity to various market parameters:
+
+```julia
+# Compute all Greeks
+greeks = compute_greeks(call, state)
+
+println("Delta: $(round(greeks.delta, digits=4))")   # Sensitivity to spot
+println("Gamma: $(round(greeks.gamma, digits=4))")   # Delta sensitivity
+println("Vega: $(round(greeks.vega, digits=4))")     # Sensitivity to vol (per 1%)
+println("Theta: $(round(greeks.theta, digits=4))")   # Time decay (per day)
+println("Rho: $(round(greeks.rho, digits=4))")       # Sensitivity to rate (per 1%)
+```
+
+### Second-Order Greeks
+
+For advanced risk management, use second-order sensitivities:
+
+```julia
+println("Vanna: $(round(greeks.vanna, digits=4))")   # ∂Delta/∂σ
+println("Volga: $(round(greeks.volga, digits=4))")   # ∂Vega/∂σ
+println("Charm: $(round(greeks.charm, digits=4))")   # ∂Delta/∂T
+```
+
+### Delta Hedging Example
+
+Use delta to construct a hedged portfolio:
+
+```julia
+# Long 100 calls
+num_calls = 100
+option_value = price(call, state) * num_calls
+delta_exposure = greeks.delta * num_calls
+
+# Hedge with stock
+shares_to_short = -delta_exposure
+
+println("Portfolio value: \$$(round(option_value, digits=2))")
+println("Shares to short for delta hedge: $(round(shares_to_short, digits=1))")
+
+# Verify hedge - if stock moves up $1
+S_new = 151.0
+state_new = MarketState(
+    prices = Dict("AAPL" => S_new),
+    rates = Dict("USD" => 0.05),
+    volatilities = Dict("AAPL" => 0.20)
+)
+
+# P&L breakdown
+option_pnl = (price(call, state_new) - price(call, state)) * num_calls
+stock_pnl = shares_to_short * (S_new - 150.0)
+total_pnl = option_pnl + stock_pnl
+
+println("\nFor \$1 spot move:")
+println("Option P&L: \$$(round(option_pnl, digits=2))")
+println("Stock hedge P&L: \$$(round(stock_pnl, digits=2))")
+println("Net P&L (should be ≈0): \$$(round(total_pnl, digits=2))")
+```
+
+## Implied Volatility
+
+Back out the volatility from a market price:
+
+```julia
+# Given a market price, find implied volatility
+market_price = 8.50  # Observed option price
+S, K, T, r = 150.0, 155.0, 0.5, 0.05
+
+# Bisection search for implied vol
+function implied_vol(market_price, S, K, T, r, opttype; tol=1e-6)
+    σ_low, σ_high = 0.01, 2.0
+
+    for _ in 1:100
+        σ_mid = (σ_low + σ_high) / 2
+        model_price = black_scholes(S, K, T, r, σ_mid, opttype)
+
+        if abs(model_price - market_price) < tol
+            return σ_mid
+        elseif model_price > market_price
+            σ_high = σ_mid
+        else
+            σ_low = σ_mid
+        end
+    end
+    return (σ_low + σ_high) / 2
+end
+
+iv = implied_vol(market_price, S, K, T, r, :call)
+println("Implied volatility: $(round(iv * 100, digits=2))%")
+
+# Verify
+model_price = black_scholes(S, K, T, r, iv, :call)
+println("Model price at IV: \$$(round(model_price, digits=4))")
+```
+
+## Volatility Smile
+
+Plot implied volatility across strikes:
+
+```julia
+# Generate a volatility smile
+strikes = 130.0:5.0:170.0
+spot = 150.0
+
+# Simulate market prices with skew (in practice, use real quotes)
+# Higher vol for low strikes (downside skew)
+function skewed_vol(K, S, base_vol=0.20)
+    moneyness = log(K/S)
+    skew = -0.15 * moneyness  # Negative skew
+    smile = 0.05 * moneyness^2  # Smile curvature
+    return base_vol + skew + smile
+end
+
+println("Strike | True Vol | Market Price | Implied Vol")
+println("-"^50)
+for K in strikes
+    true_vol = skewed_vol(K, spot)
+    market_price = black_scholes(spot, K, 0.5, 0.05, true_vol, :call)
+    iv = implied_vol(market_price, spot, K, 0.5, 0.05, :call)
+    println("$(Int(K))    | $(round(true_vol*100, digits=1))%      | \$$(round(market_price, digits=2))       | $(round(iv*100, digits=1))%")
+end
+```
+
+## Edge Cases
+
+Quasar handles edge cases gracefully:
+
+```julia
+# At expiry (T = 0)
+expired = black_scholes(150.0, 155.0, 0.0, 0.05, 0.2, :call)
+println("Expired OTM call: \$$(expired)")  # Should be 0
+
+expired_itm = black_scholes(160.0, 155.0, 0.0, 0.05, 0.2, :call)
+println("Expired ITM call: \$$(expired_itm)")  # Should be S - K = 5
+
+# Zero volatility (deterministic forward)
+deterministic = black_scholes(150.0, 140.0, 1.0, 0.05, 0.0, :call)
+forward = 150.0 * exp(0.05)  # S * exp(rT)
+intrinsic = max(forward - 140.0, 0) * exp(-0.05)  # Discounted payoff
+println("Zero vol call: \$$(round(deterministic, digits=4)) (should be ≈\$$(round(intrinsic, digits=4)))")
+```
+
+## Next Steps
+
+- [Portfolio Risk](portfolio-risk.md) - Combine options into portfolios
+- [Monte Carlo Pricing](monte-carlo-exotic.md) - Price exotic options
+- [Interest Rates](yield-curve.md) - Build yield curves for discounting

--- a/docs/src/examples/portfolio-risk.md
+++ b/docs/src/examples/portfolio-risk.md
@@ -1,0 +1,315 @@
+# Portfolio Risk Management
+
+This example demonstrates building and analyzing a portfolio of options, computing aggregate Greeks, and measuring risk.
+
+## Setup
+
+```julia
+using Quasar
+using Statistics
+```
+
+## Building a Portfolio
+
+### Creating Instruments
+
+```julia
+# Define market state
+state = MarketState(
+    prices = Dict("AAPL" => 150.0, "GOOGL" => 140.0, "MSFT" => 380.0),
+    rates = Dict("USD" => 0.05),
+    volatilities = Dict("AAPL" => 0.25, "GOOGL" => 0.30, "MSFT" => 0.22)
+)
+
+# Create various options
+options = [
+    EuropeanOption("AAPL", 155.0, 0.5, :call),   # AAPL 155 Call
+    EuropeanOption("AAPL", 145.0, 0.5, :put),    # AAPL 145 Put
+    EuropeanOption("GOOGL", 145.0, 0.5, :call),  # GOOGL 145 Call
+    EuropeanOption("MSFT", 390.0, 0.25, :call),  # MSFT 390 Call (shorter dated)
+]
+
+# Position sizes (contracts, each representing 100 shares)
+positions = [10.0, -5.0, 20.0, 15.0]  # Long 10 AAPL calls, short 5 AAPL puts, etc.
+
+# Create portfolio
+portfolio = Portfolio(options, positions)
+```
+
+### Portfolio Valuation
+
+```julia
+# Total portfolio value
+total_value = value(portfolio, state)
+println("Portfolio Value: \$$(round(total_value, digits=2))")
+
+# Breakdown by position
+println("\nPosition Breakdown:")
+for (i, (opt, pos)) in enumerate(zip(portfolio.instruments, portfolio.weights))
+    opt_price = price(opt, state)
+    pos_value = opt_price * pos
+    println("  $(i). $(opt.underlying) $(Int(opt.strike)) $(opt.optiontype): $(Int(pos)) × \$$(round(opt_price, digits=2)) = \$$(round(pos_value, digits=2))")
+end
+```
+
+## Aggregate Greeks
+
+```julia
+# Portfolio-level Greeks
+greeks = portfolio_greeks(portfolio, state)
+
+println("\nPortfolio Greeks:")
+println("  Delta: $(round(greeks.delta, digits=2))")
+println("  Gamma: $(round(greeks.gamma, digits=4))")
+println("  Vega:  $(round(greeks.vega, digits=2))")
+println("  Theta: $(round(greeks.theta, digits=2))")
+println("  Rho:   $(round(greeks.rho, digits=2))")
+```
+
+### Greeks by Underlying
+
+```julia
+# Decompose Greeks by underlying
+function greeks_by_underlying(portfolio, state)
+    greeks_map = Dict{String, NamedTuple}()
+
+    for (opt, pos) in zip(portfolio.instruments, portfolio.weights)
+        g = compute_greeks(opt, state)
+        underlying = opt.underlying
+
+        if haskey(greeks_map, underlying)
+            prev = greeks_map[underlying]
+            greeks_map[underlying] = (
+                delta = prev.delta + g.delta * pos,
+                gamma = prev.gamma + g.gamma * pos,
+                vega = prev.vega + g.vega * pos,
+            )
+        else
+            greeks_map[underlying] = (
+                delta = g.delta * pos,
+                gamma = g.gamma * pos,
+                vega = g.vega * pos,
+            )
+        end
+    end
+    return greeks_map
+end
+
+println("\nGreeks by Underlying:")
+for (underlying, g) in greeks_by_underlying(portfolio, state)
+    println("  $underlying: Δ=$(round(g.delta, digits=2)), Γ=$(round(g.gamma, digits=4)), V=$(round(g.vega, digits=2))")
+end
+```
+
+## Risk Metrics
+
+### Value at Risk (VaR)
+
+```julia
+# Simulate portfolio returns
+function simulate_portfolio_pnl(portfolio, state, n_scenarios;
+                                 spot_vol=0.02, vol_change=0.05)
+    pnls = zeros(n_scenarios)
+    base_value = value(portfolio, state)
+
+    for i in 1:n_scenarios
+        # Simulate correlated shocks
+        spot_shock_aapl = randn() * spot_vol
+        spot_shock_googl = randn() * spot_vol
+        spot_shock_msft = randn() * spot_vol
+        vol_shock = randn() * vol_change
+
+        # Create shocked state
+        shocked_state = MarketState(
+            prices = Dict(
+                "AAPL" => state.prices["AAPL"] * (1 + spot_shock_aapl),
+                "GOOGL" => state.prices["GOOGL"] * (1 + spot_shock_googl),
+                "MSFT" => state.prices["MSFT"] * (1 + spot_shock_msft),
+            ),
+            rates = Dict("USD" => 0.05),
+            volatilities = Dict(
+                "AAPL" => max(0.05, state.volatilities["AAPL"] * (1 + vol_shock)),
+                "GOOGL" => max(0.05, state.volatilities["GOOGL"] * (1 + vol_shock)),
+                "MSFT" => max(0.05, state.volatilities["MSFT"] * (1 + vol_shock)),
+            )
+        )
+
+        pnls[i] = value(portfolio, shocked_state) - base_value
+    end
+    return pnls
+end
+
+# Generate scenarios
+pnls = simulate_portfolio_pnl(portfolio, state, 10000)
+
+# Compute risk metrics
+var_95 = compute(VaR(0.95), -pnls)  # Note: VaR uses losses, not P&L
+var_99 = compute(VaR(0.99), -pnls)
+cvar_95 = compute(CVaR(0.95), -pnls)
+
+println("\nRisk Metrics (1-day, simulated):")
+println("  95% VaR:  \$$(round(var_95, digits=2))")
+println("  99% VaR:  \$$(round(var_99, digits=2))")
+println("  95% CVaR: \$$(round(cvar_95, digits=2))")
+```
+
+### Greeks-Based VaR
+
+A faster approximation using delta-gamma:
+
+```julia
+function delta_gamma_var(portfolio, state; spot_shock=0.02, confidence=0.95)
+    greeks = portfolio_greeks(portfolio, state)
+    base_value = value(portfolio, state)
+
+    # Approximate portfolio value change using Taylor expansion
+    # ΔV ≈ Δ·ΔS + ½·Γ·(ΔS)²
+
+    # For a normal distribution, find the shock at the given percentile
+    z = quantile_normal(confidence)  # ≈ 1.645 for 95%
+
+    # Aggregate spot exposure (simplified - assumes single underlying)
+    S = state.prices["AAPL"]
+    ΔS = -z * spot_shock * S  # Adverse move
+
+    # Delta-gamma approximation
+    approx_loss = -(greeks.delta * ΔS + 0.5 * greeks.gamma * ΔS^2)
+
+    return max(0, approx_loss)
+end
+
+# Simple normal quantile approximation
+function quantile_normal(p)
+    # Rational approximation
+    t = sqrt(-2 * log(1 - p))
+    return t - (2.515517 + 0.802853*t + 0.010328*t^2) /
+               (1 + 1.432788*t + 0.189269*t^2 + 0.001308*t^3)
+end
+
+dg_var = delta_gamma_var(portfolio, state)
+println("\nDelta-Gamma VaR (95%): \$$(round(dg_var, digits=2))")
+```
+
+## Stress Testing
+
+```julia
+# Define stress scenarios
+scenarios = [
+    ("Market Crash (-10%)", Dict("AAPL" => 0.90, "GOOGL" => 0.90, "MSFT" => 0.90), 1.5),
+    ("Tech Rally (+5%)", Dict("AAPL" => 1.05, "GOOGL" => 1.05, "MSFT" => 1.05), 0.9),
+    ("Vol Spike", Dict("AAPL" => 1.0, "GOOGL" => 1.0, "MSFT" => 1.0), 1.5),
+    ("Rate Hike", Dict("AAPL" => 0.98, "GOOGL" => 0.98, "MSFT" => 0.98), 1.0),
+]
+
+println("\nStress Test Results:")
+println("-"^60)
+base_value = value(portfolio, state)
+
+for (name, spot_mult, vol_mult) in scenarios
+    stressed_state = MarketState(
+        prices = Dict(k => state.prices[k] * spot_mult[k] for k in keys(state.prices)),
+        rates = Dict("USD" => 0.05),
+        volatilities = Dict(k => state.volatilities[k] * vol_mult for k in keys(state.volatilities))
+    )
+
+    stressed_value = value(portfolio, stressed_state)
+    pnl = stressed_value - base_value
+    pct_change = 100 * pnl / base_value
+
+    println("$(rpad(name, 20)) | P&L: \$$(lpad(round(pnl, digits=2), 10)) | $(round(pct_change, digits=1))%")
+end
+```
+
+## Hedging Strategies
+
+### Delta Hedging
+
+```julia
+# Current delta exposure by underlying
+delta_exposure = Dict{String, Float64}()
+for (opt, pos) in zip(portfolio.instruments, portfolio.weights)
+    g = compute_greeks(opt, state)
+    underlying = opt.underlying
+    delta_exposure[underlying] = get(delta_exposure, underlying, 0.0) + g.delta * pos
+end
+
+println("\nDelta Hedge Required:")
+for (underlying, delta) in delta_exposure
+    shares = -delta * 100  # Convert to shares (100 shares per contract)
+    S = state.prices[underlying]
+    cost = abs(shares) * S
+    println("  $underlying: $(round(shares, digits=0)) shares (\$$(round(cost, digits=0)))")
+end
+```
+
+### Vega Hedging
+
+```julia
+# Find portfolio vega
+total_vega = portfolio_greeks(portfolio, state).vega
+
+println("\nVega Exposure: $(round(total_vega, digits=2))")
+
+# To hedge, we need an option with known vega
+# Example: use a 1-month ATM straddle
+hedge_call = EuropeanOption("AAPL", 150.0, 1/12, :call)
+hedge_put = EuropeanOption("AAPL", 150.0, 1/12, :put)
+
+hedge_call_vega = compute_greeks(hedge_call, state).vega
+hedge_put_vega = compute_greeks(hedge_put, state).vega
+straddle_vega = hedge_call_vega + hedge_put_vega
+
+contracts_needed = -total_vega / straddle_vega
+println("Hedge with $(round(contracts_needed, digits=1)) AAPL 150 straddles (1M)")
+```
+
+## Attribution Analysis
+
+```julia
+# P&L attribution after a market move
+function pnl_attribution(portfolio, old_state, new_state)
+    old_value = value(portfolio, old_state)
+    new_value = value(portfolio, new_state)
+    total_pnl = new_value - old_value
+
+    greeks = portfolio_greeks(portfolio, old_state)
+
+    # Approximate contributions (simplified for single underlying)
+    S_old = old_state.prices["AAPL"]
+    S_new = new_state.prices["AAPL"]
+    ΔS = S_new - S_old
+
+    σ_old = old_state.volatilities["AAPL"]
+    σ_new = new_state.volatilities["AAPL"]
+    Δσ = σ_new - σ_old
+
+    delta_pnl = greeks.delta * ΔS
+    gamma_pnl = 0.5 * greeks.gamma * ΔS^2
+    vega_pnl = greeks.vega * Δσ * 100  # Vega is per 1%
+    unexplained = total_pnl - delta_pnl - gamma_pnl - vega_pnl
+
+    return (total=total_pnl, delta=delta_pnl, gamma=gamma_pnl,
+            vega=vega_pnl, unexplained=unexplained)
+end
+
+# Simulate a market move
+new_state = MarketState(
+    prices = Dict("AAPL" => 153.0, "GOOGL" => 142.0, "MSFT" => 385.0),
+    rates = Dict("USD" => 0.05),
+    volatilities = Dict("AAPL" => 0.27, "GOOGL" => 0.32, "MSFT" => 0.24)
+)
+
+attr = pnl_attribution(portfolio, state, new_state)
+println("\nP&L Attribution:")
+println("  Total P&L:   \$$(round(attr.total, digits=2))")
+println("  Delta:       \$$(round(attr.delta, digits=2))")
+println("  Gamma:       \$$(round(attr.gamma, digits=2))")
+println("  Vega:        \$$(round(attr.vega, digits=2))")
+println("  Unexplained: \$$(round(attr.unexplained, digits=2))")
+```
+
+## Next Steps
+
+- [Yield Curve](yield-curve.md) - Interest rate modeling
+- [Monte Carlo](monte-carlo-exotic.md) - Path-dependent options
+- [Optimization](../manual/optimization.md) - Portfolio optimization

--- a/docs/src/examples/yield-curve.md
+++ b/docs/src/examples/yield-curve.md
@@ -1,0 +1,380 @@
+# Yield Curve Construction
+
+This example demonstrates building yield curves from market data, pricing fixed income instruments, and analyzing interest rate risk.
+
+## Setup
+
+```julia
+using Quasar
+```
+
+## Curve Representations
+
+Quasar provides three equivalent curve representations:
+
+```julia
+# Times and rates for examples
+times = [0.0, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]
+
+# Discount curve - stores discount factors P(0,T)
+discount_factors = [1.0, 0.9876, 0.9753, 0.9512, 0.9048, 0.7788, 0.6065]
+dc = DiscountCurve(times, discount_factors)
+
+# Zero curve - stores continuously compounded rates
+zero_rates = [0.05, 0.05, 0.0505, 0.05, 0.05, 0.05, 0.05]
+zc = ZeroCurve(times, zero_rates)
+
+# Forward curve - stores instantaneous forward rates
+fwd_rates = [0.05, 0.0505, 0.051, 0.05, 0.05, 0.05, 0.05]
+fc = ForwardCurve(times, fwd_rates)
+
+# All curves support the same interface
+println("Discount factors at 2Y:")
+println("  DiscountCurve: $(round(discount(dc, 2.0), digits=6))")
+println("  ZeroCurve:     $(round(discount(zc, 2.0), digits=6))")
+```
+
+### Flat Curves
+
+For quick calculations, use flat curves:
+
+```julia
+flat = ZeroCurve(0.05)  # 5% flat rate
+println("\n5% flat curve:")
+println("  1Y discount: $(round(discount(flat, 1.0), digits=4))")
+println("  5Y discount: $(round(discount(flat, 5.0), digits=4))")
+println("  10Y discount: $(round(discount(flat, 10.0), digits=4))")
+```
+
+## Curve Operations
+
+```julia
+curve = ZeroCurve(times, zero_rates)
+
+# Discount factor from 0 to T
+P_5Y = discount(curve, 5.0)
+println("\n5Y discount factor: $(round(P_5Y, digits=6))")
+
+# Zero rate to time T (continuously compounded)
+z_5Y = zero_rate(curve, 5.0)
+println("5Y zero rate: $(round(z_5Y * 100, digits=3))%")
+
+# Forward rate between T1 and T2 (simply compounded)
+f_1Y_2Y = forward_rate(curve, 1.0, 2.0)
+println("1Y-2Y forward rate: $(round(f_1Y_2Y * 100, digits=3))%")
+
+# Instantaneous forward rate at T
+inst_fwd = instantaneous_forward(curve, 2.0)
+println("Instantaneous forward at 2Y: $(round(inst_fwd * 100, digits=3))%")
+```
+
+## Bootstrapping from Market Instruments
+
+Build curves from observable market rates:
+
+```julia
+# Market instruments
+instruments = [
+    DepositRate(0.25, 0.048),    # 3M deposit at 4.8%
+    DepositRate(0.5, 0.049),     # 6M deposit at 4.9%
+    FuturesRate(0.5, 0.75, 0.050),  # 6M-9M futures at 5.0%
+    SwapRate(1.0, 0.050),        # 1Y swap at 5.0%
+    SwapRate(2.0, 0.052),        # 2Y swap at 5.2%
+    SwapRate(5.0, 0.055),        # 5Y swap at 5.5%
+    SwapRate(10.0, 0.058),       # 10Y swap at 5.8%
+]
+
+# Bootstrap the curve
+curve = bootstrap(instruments)
+
+println("\nBootstrapped Curve:")
+println("Maturity | Zero Rate | Discount")
+println("-"^35)
+for T in [0.25, 0.5, 1.0, 2.0, 5.0, 10.0]
+    z = zero_rate(curve, T)
+    d = discount(curve, T)
+    println("$(rpad("$(T)Y", 9)) | $(round(z*100, digits=3))%    | $(round(d, digits=6))")
+end
+```
+
+### Interpolation Methods
+
+Different interpolation affects the curve shape:
+
+```julia
+# Compare interpolation methods
+curve_linear = bootstrap(instruments; interp=LinearInterp())
+curve_loglin = bootstrap(instruments; interp=LogLinearInterp())
+curve_spline = bootstrap(instruments; interp=CubicSplineInterp())
+
+println("\n2.5Y Zero Rate by Interpolation Method:")
+println("  Linear:     $(round(zero_rate(curve_linear, 2.5)*100, digits=4))%")
+println("  Log-linear: $(round(zero_rate(curve_loglin, 2.5)*100, digits=4))%")
+println("  Cubic spline: $(round(zero_rate(curve_spline, 2.5)*100, digits=4))%")
+```
+
+## Parametric Curves
+
+### Nelson-Siegel Model
+
+The Nelson-Siegel model provides smooth, parsimonious curves:
+
+```julia
+# Fit Nelson-Siegel to market data
+maturities = [0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]
+observed_rates = [0.048, 0.049, 0.050, 0.052, 0.055, 0.058, 0.060]
+
+ns_curve = fit_nelson_siegel(maturities, observed_rates)
+
+println("\nNelson-Siegel Parameters:")
+println("  β₀ (level): $(round(ns_curve.β0, digits=4))")
+println("  β₁ (slope): $(round(ns_curve.β1, digits=4))")
+println("  β₂ (curvature): $(round(ns_curve.β2, digits=4))")
+println("  τ (decay): $(round(ns_curve.τ, digits=4))")
+
+# Evaluate the fitted curve
+println("\nFitted vs Observed:")
+for (T, obs) in zip(maturities, observed_rates)
+    fitted = zero_rate(ns_curve, T)
+    error = (fitted - obs) * 10000  # basis points
+    println("  $(T)Y: fitted=$(round(fitted*100, digits=3))%, obs=$(round(obs*100, digits=3))%, error=$(round(error, digits=2))bp")
+end
+```
+
+### Svensson Extension
+
+For more complex shapes, use the Svensson model (adds a second hump):
+
+```julia
+sv_curve = fit_svensson(maturities, observed_rates)
+
+println("\nSvensson Parameters:")
+println("  β₀: $(round(sv_curve.β0, digits=4))")
+println("  β₁: $(round(sv_curve.β1, digits=4))")
+println("  β₂: $(round(sv_curve.β2, digits=4))")
+println("  β₃: $(round(sv_curve.β3, digits=4))")
+println("  τ₁: $(round(sv_curve.τ1, digits=4))")
+println("  τ₂: $(round(sv_curve.τ2, digits=4))")
+```
+
+## Bond Pricing
+
+### Zero-Coupon Bonds
+
+```julia
+# 5-year zero-coupon bond
+zcb = ZeroCouponBond(5.0)  # Face value 100
+zcb_custom = ZeroCouponBond(5.0, 1000.0)  # Face value 1000
+
+# Price using curve
+pv = price(zcb, curve)
+println("\n5Y Zero-Coupon Bond:")
+println("  Price: \$$(round(pv, digits=4))")
+println("  Yield: $(round(-log(pv/100)/5 * 100, digits=3))%")
+```
+
+### Coupon Bonds
+
+```julia
+# 5-year bond, 6% coupon, semi-annual
+bond = FixedRateBond(5.0, 0.06, 2)
+
+# Price at a yield
+pv_yield = price(bond, 0.055)  # Price at 5.5% yield
+println("\n5Y 6% Coupon Bond:")
+println("  Price at 5.5% yield: \$$(round(pv_yield, digits=4))")
+
+# Price using curve
+pv_curve = price(bond, curve)
+println("  Price using market curve: \$$(round(pv_curve, digits=4))")
+
+# Yield to maturity
+ytm = yield_to_maturity(bond, pv_curve)
+println("  YTM: $(round(ytm * 100, digits=3))%")
+```
+
+### Bond Analytics
+
+```julia
+# Duration measures
+y = 0.055
+mac_dur = duration(bond, y)
+mod_dur = modified_duration(bond, y)
+convex = convexity(bond, y)
+dv = dv01(bond, y)
+
+println("\nBond Analytics at 5.5% yield:")
+println("  Macaulay Duration: $(round(mac_dur, digits=3)) years")
+println("  Modified Duration: $(round(mod_dur, digits=3))")
+println("  Convexity: $(round(convex, digits=3))")
+println("  DV01: \$$(round(dv, digits=4)) per bp")
+
+# Duration-based price approximation
+Δy = 0.01  # 100bp rate increase
+price_actual = price(bond, y + Δy)
+price_duration = pv_yield * (1 - mod_dur * Δy)
+price_convexity = pv_yield * (1 - mod_dur * Δy + 0.5 * convex * Δy^2)
+
+println("\nPrice Change for +100bp:")
+println("  Actual: \$$(round(price_actual - pv_yield, digits=4))")
+println("  Duration approx: \$$(round(price_duration - pv_yield, digits=4))")
+println("  Duration+Convexity: \$$(round(price_convexity - pv_yield, digits=4))")
+```
+
+## Day Count Conventions
+
+```julia
+using Dates
+
+# Different conventions for accrual periods
+start_date = Date(2024, 1, 15)
+end_date = Date(2024, 7, 15)
+
+yf_act360 = year_fraction(start_date, end_date, ACT360())
+yf_act365 = year_fraction(start_date, end_date, ACT365())
+yf_30360 = year_fraction(start_date, end_date, Thirty360())
+yf_actact = year_fraction(start_date, end_date, ACTACT())
+
+println("\nYear Fractions (Jan 15 to Jul 15, 2024):")
+println("  ACT/360: $(round(yf_act360, digits=6))")
+println("  ACT/365: $(round(yf_act365, digits=6))")
+println("  30/360:  $(round(yf_30360, digits=6))")
+println("  ACT/ACT: $(round(yf_actact, digits=6))")
+```
+
+## Interest Rate Derivatives
+
+### Caps and Floors
+
+```julia
+curve = ZeroCurve(0.05)
+cap_vol = 0.20  # 20% Black volatility
+
+# Price a 5-year cap at 5% strike
+cap = Cap(5.0, 0.05)
+cap_price = black_cap(cap, curve, cap_vol)
+println("\n5Y Cap at 5%:")
+println("  Price: \$$(round(cap_price * 10000, digits=2)) per \$10,000 notional")
+
+# Price a floor
+floor = Floor(5.0, 0.04)
+floor_price = black_floor(floor, curve, cap_vol)
+println("5Y Floor at 4%:")
+println("  Price: \$$(round(floor_price * 10000, digits=2)) per \$10,000 notional")
+```
+
+### Swaptions
+
+```julia
+swaption_vol = 0.15
+
+# 1Y into 5Y payer swaption at 5% strike
+payer = Swaption(1.0, 6.0, 0.05, true)
+payer_price = price(payer, curve, swaption_vol)
+
+receiver = Swaption(1.0, 6.0, 0.05, false)
+receiver_price = price(receiver, curve, swaption_vol)
+
+println("\n1Y x 5Y Swaptions at 5%:")
+println("  Payer: \$$(round(payer_price * 10000, digits=2)) per \$10,000")
+println("  Receiver: \$$(round(receiver_price * 10000, digits=2)) per \$10,000")
+```
+
+## Short-Rate Models
+
+### Vasicek Model
+
+```julia
+# Vasicek: dr = κ(θ - r)dt + σdW
+vasicek = Vasicek(
+    0.3,    # κ - mean reversion speed
+    0.05,   # θ - long-term mean
+    0.015,  # σ - volatility
+    0.03    # r₀ - initial rate
+)
+
+# Analytical bond prices
+println("\nVasicek Bond Prices:")
+for T in [1.0, 2.0, 5.0, 10.0]
+    P = bond_price(vasicek, T)
+    implied_yield = -log(P) / T
+    println("  $(Int(T))Y: P=$(round(P, digits=6)), yield=$(round(implied_yield*100, digits=3))%")
+end
+
+# Simulate rate paths
+paths = simulate_short_rate(vasicek, 5.0, 252, 1000)
+terminal_rates = paths[end, :]
+
+println("\n5Y Rate Distribution (Vasicek):")
+println("  Mean: $(round(mean(terminal_rates)*100, digits=3))%")
+println("  Std:  $(round(std(terminal_rates)*100, digits=3))%")
+println("  Min:  $(round(minimum(terminal_rates)*100, digits=3))%")
+println("  Max:  $(round(maximum(terminal_rates)*100, digits=3))%")
+```
+
+### CIR Model
+
+```julia
+# CIR: dr = κ(θ - r)dt + σ√r dW (ensures r > 0)
+cir = CIR(0.3, 0.05, 0.10, 0.03)
+
+# Check Feller condition: 2κθ > σ²
+feller = 2 * 0.3 * 0.05 > 0.10^2
+println("\nCIR Model:")
+println("  Feller condition satisfied: $feller")
+
+paths_cir = simulate_short_rate(cir, 5.0, 252, 1000)
+println("  All rates positive: $(all(paths_cir .>= 0))")
+```
+
+### Hull-White Model
+
+```julia
+# Hull-White calibrated to market curve
+market_curve = ZeroCurve([0.0, 1.0, 2.0, 5.0, 10.0], [0.03, 0.035, 0.04, 0.045, 0.05])
+hw = HullWhite(0.1, 0.01, market_curve)
+
+# Bond prices match market exactly
+println("\nHull-White (calibrated to market):")
+for T in [1.0, 2.0, 5.0]
+    hw_price = bond_price(hw, T)
+    market_price = discount(market_curve, T)
+    println("  $(Int(T))Y: HW=$(round(hw_price, digits=6)), Market=$(round(market_price, digits=6))")
+end
+```
+
+## Curve Risk (Key Rate Duration)
+
+```julia
+# Measure sensitivity to key rate shocks
+function key_rate_duration(bond, curve, key_tenors; shock=0.0001)
+    base_price = price(bond, curve)
+    krds = Float64[]
+
+    for tenor in key_tenors
+        # Shock the curve at this tenor
+        shocked_curve = shock_curve_at_tenor(curve, tenor, shock)
+        shocked_price = price(bond, shocked_curve)
+        krd = -(shocked_price - base_price) / (shock * base_price)
+        push!(krds, krd)
+    end
+    return krds
+end
+
+# Helper to shock curve at specific tenor
+function shock_curve_at_tenor(curve, tenor, shock)
+    # Simplified: just shift all rates (in practice, use localized bump)
+    times = [0.0, 1.0, 2.0, 5.0, 10.0]
+    rates = [zero_rate(curve, t) + (t == tenor ? shock : 0) for t in times]
+    return ZeroCurve(times, rates)
+end
+
+# Note: This is a simplified example; production code would use
+# proper key rate duration calculation with localized bumps
+```
+
+## Next Steps
+
+- [Monte Carlo Exotic](monte-carlo-exotic.md) - Exotic option pricing
+- [Option Pricing](option-pricing.md) - Black-Scholes options
+- [Interest Rates Manual](../manual/interest-rates.md) - Full reference


### PR DESCRIPTION
## Summary
- Add 4 comprehensive example tutorials to the documentation
- Option pricing walkthrough (Black-Scholes, Greeks, implied volatility)
- Portfolio risk management (VaR, stress testing, hedging)
- Yield curve construction (bootstrapping, Nelson-Siegel, bonds)
- Monte Carlo exotic options (Asian, barrier, American, Heston)

## Test plan
- [x] Documentation builds successfully with `julia --project=docs -e 'include("docs/make.jl")'`
- [ ] Review examples render correctly in VitePress